### PR TITLE
Add the ability to specify colors

### DIFF
--- a/autoload/fern/renderer/devicons.vim
+++ b/autoload/fern/renderer/devicons.vim
@@ -32,9 +32,8 @@ function! s:render(nodes, marks) abort
 endfunction
 
 function! s:syntax() abort
-  syntax clear
-  syntax match FernLeaf   /^\s*[^ ]\+/
-  syntax match FernBranch /^\s*.*\/$/
+  syntax match FernLeaf  /^\s*[^\x00-\x7F]/ nextgroup=FernBranch
+  syntax match FernBranch /\s*.*\/$/ contained
   syntax match FernRoot   /\%1l.*/
   execute printf(
         \ 'syntax match FernMarked /^%s.*/',

--- a/doc/fern-renderer-devicons.txt
+++ b/doc/fern-renderer-devicons.txt
@@ -75,8 +75,11 @@ VARIABLE				*fern-renderer-devicons-variable*
 -----------------------------------------------------------------------------
 COLORS				*fern-renderer-devicons-colors*
 
-You can specify colors manually by just defining syntax for fern buffer.
-See examples at https://github.com/ryanoasis/vim-devicons/issues/158.
+Unfortunately vim-devicons does not provide an API for this. But you can
+specify colors manually by just defining syntax for fern buffer.
+See example https://github.com/ryanoasis/vim-devicons/issues/158#issue-166035270 or
+https://github.com/ryanoasis/vim-devicons/issues/158#issuecomment-643139346 or
+https://github.com/ryanoasis/vim-devicons/issues/158#issuecomment-661974266.
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/fern-renderer-devicons.txt
+++ b/doc/fern-renderer-devicons.txt
@@ -7,6 +7,7 @@ INTRODUCTION			|fern-renderer-devicons-introduction|
 USAGE				|fern-renderer-devicons-usage|
 INTERFACE			|fern-renderer-devicons-interface|
   VARIABLE			|fern-renderer-devicons-variable|
+  COLORS			|fern-renderer-devicons-colors|
 
 
 =============================================================================
@@ -70,6 +71,12 @@ VARIABLE				*fern-renderer-devicons-variable*
 	* |  gamma
 <
 	Default: "   "
+
+-----------------------------------------------------------------------------
+COLORS				*fern-renderer-devicons-colors*
+
+You can specify colors manually by just defining syntax for fern buffer.
+See examples at https://github.com/ryanoasis/vim-devicons/issues/158.
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl


### PR DESCRIPTION
I realized that we do not even need to override `s:highlight`. Need to simply remove `syntax clear` (this command not needed because default `s:highlight` implementation is not called and it just clears all user-defined syntax). I also left small syntax improvement. Let me know If you okay with it. Closes #4.